### PR TITLE
Force stylelint 14.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
     "faucet": "^0.0.1",
     "klaw": "^4.0.1",
     "tape": "^5.5.3"
+  },
+  "overrides": {
+    "stylelint-order": "5.0.0",
+    "stylelint": "14.14.0"
   }
 }


### PR DESCRIPTION
stylelint 14.14.0 will be the last version for the original stylefmt. or update `/lib/params.js` such that `stylelint.isPathIgnored(file)` fits to the latest API in Stylelint.

The current version is "14.8.2"
File size can get minimized when upgraded to "14.9.1"
Last working version without modifying stylefmt is "14.14.0"
Since 14.14.1, `stylelint.isPathIgnored` is no longer available.
Since 15.x.x, stylelint's APIs are all changed.